### PR TITLE
Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>HCA Data Preview</title>
+    <title>HCA Data Portal</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     
     <!-- Favicon -->
@@ -42,5 +42,75 @@
             </section>
         </div>
     </header>
+    <div class="page-container mdc-layout-grid">
+        <div class="mdc-layout-grid__inner">
+            <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+                <section class="jumbotron">
+                    <h2 class="value-prop">Download Human Cell Atlas Preview Datasets</h2>
+                    <p class="description">These preliminary datasets include only FASTQ files and metadata. Secondary analysis results such as BAMs and expression counts will be made available in summer 2018. If you have questions please email <a href="mailto:data-help@humancellatlas.org">data-help@humancellatlas.org</a>.</p>
+                </section>
+                <section class="preview-datasets">
+                    <h3>Preview Datasets</h3>
+                    <div class="previews">
+                        <div class="preview">
+                            <div>
+                                <h5>Immune Cell Atlas</h5>
+                                <h6>Dr. Aviv Ragev</h6>
+                                <h6>Broad Inst.</h6>
+                                <p>
+                                    Sed posuere consectetur est at lobortis. Duis mollis, est non commodo luctus, nisi erat.
+                                </p>
+                            </div>
+                            <div>
+                                <h6>1 million cells</h6>
+                                <h6>3TB of data</h6>
+                                <h6 class="highlight-blue">ABC123</h6>
+                            </div>
+                        </div>
+                        <div class="preview">
+                            <div>
+                                <h5>T-cells from Mouse Melanoma</h5>
+                                <h6>Dr. Sarah Teichmann</h6>
+                                <h6>Sanger Inst.</h6>
+                                <p>
+                                    Sed posuere consectetur est at lobortis. Duis mollis, est non commodo luctus, nisi erat.
+                                </p>    
+                            </div>
+                            <div>
+                                <h6>50,000 cells</h6>
+                                <h6>1.5TB of data</h6>
+                                <h6 class="highlight-blue">EFF123</h6>
+                            </div>
+                        </div>
+                        <div class="preview">
+                            <div>
+                                <h5>Spleen Study</h5>
+                                <h6>Dr. Mike Stubbington</h6>
+                                <h6>Sanger Inst.</h6>
+                                <p>
+                                    Sed posuere consectetur est at lobortis. Duis mollis, est non commodo luctus, nisi erat.
+                                </p>    
+                            </div>
+                            <div>
+                                <h6>30,000 cells</h6>
+                                <h6>800GB of data</h6>
+                                <h6 class="highlight-blue">BEG984</h6>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <h3>Download Instructions</h3>
+                    <p>Donec id elit non mi porta gravida at eget metus. Aenean lacinia bibendum nulla sed consectetur.</p>
+                    <h4 class="mdc-typography--title">Install the HCA CLI tool in the terminal</h4>
+                    <p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Praesent commodo cursus magna, vel scelerisque.</p>
+                    <div class="code">pip install hca</div>
+                    <h4 class="mdc-typography--title">Nullam id dolor id nibh ultricies vehicula ut id elit</h4>
+                    <p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec id elit non mi porta gravida at eget metus. Aenean lacinia bibendum nulla sed consectetur.</p>
+                    <div class="code">Nullam id dolor id nibh ultricies vehicula ut id elit.</div>
+                </section>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@material/elevation": "0.28.0",
+    "@material/layout-grid": "0.24.0",
     "@material/toolbar": "0.33.0",
     "@material/typography": "0.28.0",
     "normalize.css": "8.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@material/elevation": "0.28.0",
     "@material/layout-grid": "0.24.0",
+    "@material/theme": "0.33.0",
     "@material/toolbar": "0.33.0",
     "@material/typography": "0.28.0",
     "normalize.css": "8.0.0"

--- a/styles/hca/_hca-home.scss
+++ b/styles/hca/_hca-home.scss
@@ -1,0 +1,119 @@
+/*!
+ * Human Cell Atlas
+ * https://www.humancellatlas.org/
+ *
+ * Global styles used across components.
+ */
+
+// Dependencies
+@import "hca-vars";
+@import "@material/typography/mdc-typography";
+
+.page-container {
+    margin: 0 auto;
+    max-width: 800px;
+    &.mdc-layout-grid{
+        margin-bottom: 100px;
+    }
+    h2 {
+        @include mdc-typography(display1);
+        letter-spacing: 0;
+    }
+    h3 {
+        @include mdc-typography(headline);
+        font-weight: 500;
+        letter-spacing: 0;
+    }
+    h4 {
+        @include mdc-typography(title);
+        font-weight: 400;
+        letter-spacing: 0;
+    }
+    h5 {
+        @include mdc-typography(subheading2);
+        letter-spacing: 0;
+    }
+    h6 {
+        @include mdc-typography(subheading1);
+        letter-spacing: 0;
+    }
+    p {
+        @include mdc-typography(body1);
+        color: $hca-color-text;
+        letter-spacing: 0;
+    }
+    .preview-datasets {
+        margin-bottom: 70px;
+    }
+    .previews {
+        display: flex;
+        flex-direction: column;
+    }
+    .preview {
+        justify-content: space-between;
+        border: 1px solid $md-black-12;
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 24px;
+        padding: 16px;
+        text-align: center;
+        &:last-child {
+            margin-bottom: 0;
+        }
+        h5 {
+            font-weight: 500;
+            line-height: 1.3rem;
+            margin: 0 0 4px;
+            letter-spacing: 0;
+        }
+        h6 {
+            color: $hca-color-text;
+            letter-spacing: 0;
+            margin: 0;
+            &.highlight-blue {
+                color: #4a90e2;
+            }
+        }
+        p {
+            @include mdc-typography(caption);
+            letter-spacing: 0;
+            font-size: 0.8125rem;
+            margin-left: auto;
+            margin-right: auto;
+            max-width: 320px;
+
+        }
+    }
+    .code {
+        background-color: #f8f8f8;
+        font-family: monospace;
+        font-size: 1.125rem;
+        padding: 16px 50px;
+        position: relative;
+        &:before {
+            color: #999999;
+            content: '$';
+            left: 24px;
+            position: absolute;
+        }
+    }
+}
+
+/**
+ * Large tablet, medium +
+ */
+@media (min-width: $md-tablet-portrait-lg-min) {
+
+    .page-container {
+        .previews {
+            align-items: stretch;
+            flex-direction: row;
+            justify-content: space-between;
+            min-height: 292px;
+        }    
+        .preview {
+            margin-bottom: 0;
+            max-width: 196px;
+        }
+    }
+}

--- a/styles/hca/_hca-jumbotron.scss
+++ b/styles/hca/_hca-jumbotron.scss
@@ -1,0 +1,26 @@
+/*!
+ * Human Cell Atlas
+ * https://www.humancellatlas.org/
+ *
+ * Styles for jumbotron area.
+ */
+
+.jumbotron {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 86px;
+    margin-top: 60px; // 15px inside toolbar + 60px above text = 75px as per spec
+    text-align: center;
+
+    // Override default Material margins to space jumbotron text correct distance from toolbar and jumbotron subtext
+    .value-prop {
+        margin: 0 0 16px;
+    }
+
+    // Override default Material margins to space subtext correct distance from main text
+    .description {
+        margin: 0;
+        max-width: 600px;
+    }
+}

--- a/styles/hca/_hca-vars.scss
+++ b/styles/hca/_hca-vars.scss
@@ -6,6 +6,13 @@
  */
 
 /**
+ * Material Design black hues.
+ **/
+$md-black-12: rgba(0, 0, 0, 0.12);
+$md-black-38: rgba(0, 0, 0, 0.38);
+$md-black-57: rgba(0, 0, 0, 0.57);
+
+/**
  * Material Design media break points
  **/
 $md-xl-min: 1920px;
@@ -13,6 +20,14 @@ $md-lg-min: 1280px;
 $md-lg-max: $md-xl-min - 1;
 $md-md-min: 960px;
 $md-md-max: $md-lg-min - 1;
+$md-tablet-portrait-lg-min: 840px;
+$md-tablet-portrait-md-max: $md-tablet-portrait-lg-min - 1;
+$md-tablet-landscape-sm-min: 480px;
 $md-sm-min: 600px;
 $md-sm-max: $md-md-min - 1;
 $md-xs-max: $md-sm-min - 1;
+
+/**
+ * HCA colors.
+ */
+$hca-color-text: #4a4a4a;

--- a/styles/hca/styles.scss
+++ b/styles/hca/styles.scss
@@ -5,6 +5,10 @@
  * Global and imported styles.
  */
 
+@import "hca-home"; // Styles specific to home page
+@import "hca-jumbotron";
 @import "hca-theme";
 @import "hca-toolbar";
 @import "hca-typography";
+@import "@material/layout-grid/mdc-layout-grid"; // Layout Grid - https://material.io/components/web/catalog/layout-grid/
+


### PR DESCRIPTION
### Toolbar

- MD toolbar height is 64px and logo is centered vertically within the 64px (different from Sketch).
- Left/right padding in MD toolbar is 4n pixels, depending on device size (different from Sketch).
- Logo is always left-aligned regardless of device size. Do we want to snap the logo at a certain width? For example, on very large devices, there is a large gap between logo and center channel. Also, should logo be centered on smaller devices to match center alignment of content?

### General Layout / Global Styles

- Rounded center channel to 800px (different from Sketch).
- Added standard MD gird/gutter for center channel.
- Custom (non MD) text color for text?

### Jumbotron

- Used `display1` for value prop (instead of 36px as per Sketch).
- Overrode default MD margins to match Sketch.
- Used `body1` for description but overrode default margins to match Sketch.
- Rounded description to 600px (different from Sketch).

### Content
- Used `title` (20px) for “Install the HCA CLI..” (Sketch is 18px).
- Preview: used black 38% instead of #ccc for border.
- Preview: used 16px padding instead of 17px/15px in Sketch.
- Preview: used `subheading` (16px) for "Spleen Study" level text instead of 18px.
- Preview: review responsive.